### PR TITLE
🔒 Add rel="noopener" to target="_blank" links

### DIFF
--- a/_layouts/experience.html
+++ b/_layouts/experience.html
@@ -216,7 +216,7 @@
                </header>
                {% for job in site.data.experience %}
                <div class="experience-block">
-                  <h3><a href="{{job.url}}" target="_blank">{{job.company}}</a></h3>
+                  <h3><a href="{{job.url}}" target="_blank" rel="noopener">{{job.company}}</a></h3>
                   <span class="education-date">{{job.time}}</span>
                   <h4>{{job.position}}</h4>
                </div>

--- a/_layouts/projects.html
+++ b/_layouts/projects.html
@@ -247,7 +247,7 @@
                      <div class="card-body">
                         <h4 id="{{ project_name }}-name" class="card-title">
                            {%- if project_url -%}
-                           <a href="{{ project_url }}" target="_blank">
+                           <a href="{{ project_url }}" target="_blank" rel="noopener">
                            {%- endif -%}
                            {{ project_name }}
                            {%- if project_url -%}

--- a/microstories/terms.html
+++ b/microstories/terms.html
@@ -31,11 +31,11 @@
       <div>
          <p>Link to privacy policy of third party service providers used by the app</p>
          <ul>
-            <li><a href="https://www.google.com/policies/privacy/" target="_blank">Google Play Services</a></li>
+            <li><a href="https://www.google.com/policies/privacy/" target="_blank" rel="noopener">Google Play Services</a></li>
             <!---->
-            <li><a href="https://firebase.google.com/policies/analytics" target="_blank">Firebase Analytics</a></li>
+            <li><a href="https://firebase.google.com/policies/analytics" target="_blank" rel="noopener">Firebase Analytics</a></li>
             <!----><!---->
-            <li><a href="http://try.crashlytics.com/terms/privacy-policy.pdf" target="_blank">Crashlytics</a></li>
+            <li><a href="http://try.crashlytics.com/terms/privacy-policy.pdf" target="_blank" rel="noopener">Crashlytics</a></li>
             <!----><!----><!---->
          </ul>
       </div>

--- a/nightbear/memeapp/terms.html
+++ b/nightbear/memeapp/terms.html
@@ -21,10 +21,10 @@
 <p>Link to the privacy policy of third party service providers used by the app</p>
 
 <ul style="margin-left:0; margin-right:0">
-	<li><a href="https://www.google.com/policies/privacy/" style="color: #21759b; outline: none;" target="_blank">Google Play Services</a></li>
-	<li><a href="https://support.google.com/admob/answer/6128543?hl=en" style="color: #21759b; outline: none;" target="_blank">AdMob</a></li>
-	<li><a href="https://firebase.google.com/policies/analytics" style="color: #21759b; outline: none;" target="_blank">Firebase Analytics</a></li>
-	<li><a href="https://www.mopub.com/en/legal/privacy" style="color: #21759b; outline: none;" target="_blank">Mopub</a></li>
+	<li><a href="https://www.google.com/policies/privacy/" style="color: #21759b; outline: none;" target="_blank" rel="noopener">Google Play Services</a></li>
+	<li><a href="https://support.google.com/admob/answer/6128543?hl=en" style="color: #21759b; outline: none;" target="_blank" rel="noopener">AdMob</a></li>
+	<li><a href="https://firebase.google.com/policies/analytics" style="color: #21759b; outline: none;" target="_blank" rel="noopener">Firebase Analytics</a></li>
+	<li><a href="https://www.mopub.com/en/legal/privacy" style="color: #21759b; outline: none;" target="_blank" rel="noopener">Mopub</a></li>
 </ul>
 
 <p><strong>COLLECTION OF INFORMATION</strong></p>

--- a/nightbear/wallpaperapp/terms.html
+++ b/nightbear/wallpaperapp/terms.html
@@ -21,10 +21,10 @@
 <p>Link to the privacy policy of third party service providers used by the app</p>
 
 <ul style="margin-left:0; margin-right:0">
-	<li><a href="https://www.google.com/policies/privacy/" style="color: #21759b; outline: none;" target="_blank">Google Play Services</a></li>
-	<li><a href="https://support.google.com/admob/answer/6128543?hl=en" style="color: #21759b; outline: none;" target="_blank">AdMob</a></li>
-	<li><a href="https://firebase.google.com/policies/analytics" style="color: #21759b; outline: none;" target="_blank">Firebase Analytics</a></li>
-	<li><a href="https://www.mopub.com/en/legal/privacy" style="color: #21759b; outline: none;" target="_blank">Mopub</a></li>
+	<li><a href="https://www.google.com/policies/privacy/" style="color: #21759b; outline: none;" target="_blank" rel="noopener">Google Play Services</a></li>
+	<li><a href="https://support.google.com/admob/answer/6128543?hl=en" style="color: #21759b; outline: none;" target="_blank" rel="noopener">AdMob</a></li>
+	<li><a href="https://firebase.google.com/policies/analytics" style="color: #21759b; outline: none;" target="_blank" rel="noopener">Firebase Analytics</a></li>
+	<li><a href="https://www.mopub.com/en/legal/privacy" style="color: #21759b; outline: none;" target="_blank" rel="noopener">Mopub</a></li>
 </ul>
 
 <p><strong>COLLECTION OF INFORMATION</strong></p>

--- a/quizgamesapps/demonslayerquiz/privacy_policy.html
+++ b/quizgamesapps/demonslayerquiz/privacy_policy.html
@@ -28,11 +28,11 @@
       <div>
          <p>Link to privacy policy of third party service providers used by the app</p>
          <ul>
-            <li><a href="https://www.google.com/policies/privacy/" target="_blank">Google Play Services</a></li>
+            <li><a href="https://www.google.com/policies/privacy/" target="_blank" rel="noopener">Google Play Services</a></li>
             <!---->
-            <li><a href="https://firebase.google.com/policies/analytics" target="_blank">Firebase Analytics</a></li>
+            <li><a href="https://firebase.google.com/policies/analytics" target="_blank" rel="noopener">Firebase Analytics</a></li>
             <!----><!---->
-            <li><a href="http://try.crashlytics.com/terms/privacy-policy.pdf" target="_blank">Crashlytics</a></li>
+            <li><a href="http://try.crashlytics.com/terms/privacy-policy.pdf" target="_blank" rel="noopener">Crashlytics</a></li>
             <!----><!----><!---->
          </ul>
       </div>

--- a/quizgamesapps/genshinimpactquiz/privacy_policy.html
+++ b/quizgamesapps/genshinimpactquiz/privacy_policy.html
@@ -28,11 +28,11 @@
       <div>
          <p>Link to privacy policy of third party service providers used by the app</p>
          <ul>
-            <li><a href="https://www.google.com/policies/privacy/" target="_blank">Google Play Services</a></li>
+            <li><a href="https://www.google.com/policies/privacy/" target="_blank" rel="noopener">Google Play Services</a></li>
             <!---->
-            <li><a href="https://firebase.google.com/policies/analytics" target="_blank">Firebase Analytics</a></li>
+            <li><a href="https://firebase.google.com/policies/analytics" target="_blank" rel="noopener">Firebase Analytics</a></li>
             <!----><!---->
-            <li><a href="http://try.crashlytics.com/terms/privacy-policy.pdf" target="_blank">Crashlytics</a></li>
+            <li><a href="http://try.crashlytics.com/terms/privacy-policy.pdf" target="_blank" rel="noopener">Crashlytics</a></li>
             <!----><!----><!---->
          </ul>
       </div>

--- a/quizgamesapps/heroacademiaquiz/privacy_policy.html
+++ b/quizgamesapps/heroacademiaquiz/privacy_policy.html
@@ -28,11 +28,11 @@
       <div>
          <p>Link to privacy policy of third party service providers used by the app</p>
          <ul>
-            <li><a href="https://www.google.com/policies/privacy/" target="_blank">Google Play Services</a></li>
+            <li><a href="https://www.google.com/policies/privacy/" target="_blank" rel="noopener">Google Play Services</a></li>
             <!---->
-            <li><a href="https://firebase.google.com/policies/analytics" target="_blank">Firebase Analytics</a></li>
+            <li><a href="https://firebase.google.com/policies/analytics" target="_blank" rel="noopener">Firebase Analytics</a></li>
             <!----><!---->
-            <li><a href="http://try.crashlytics.com/terms/privacy-policy.pdf" target="_blank">Crashlytics</a></li>
+            <li><a href="http://try.crashlytics.com/terms/privacy-policy.pdf" target="_blank" rel="noopener">Crashlytics</a></li>
             <!----><!----><!---->
          </ul>
       </div>

--- a/quizgamesapps/ultimatequizapp/privacy_policy.html
+++ b/quizgamesapps/ultimatequizapp/privacy_policy.html
@@ -28,11 +28,11 @@
       <div>
          <p>Link to privacy policy of third party service providers used by the app</p>
          <ul>
-            <li><a href="https://www.google.com/policies/privacy/" target="_blank">Google Play Services</a></li>
+            <li><a href="https://www.google.com/policies/privacy/" target="_blank" rel="noopener">Google Play Services</a></li>
             <!---->
-            <li><a href="https://firebase.google.com/policies/analytics" target="_blank">Firebase Analytics</a></li>
+            <li><a href="https://firebase.google.com/policies/analytics" target="_blank" rel="noopener">Firebase Analytics</a></li>
             <!----><!---->
-            <li><a href="http://try.crashlytics.com/terms/privacy-policy.pdf" target="_blank">Crashlytics</a></li>
+            <li><a href="http://try.crashlytics.com/terms/privacy-policy.pdf" target="_blank" rel="noopener">Crashlytics</a></li>
             <!----><!----><!---->
          </ul>
       </div>

--- a/storiesoflife/terms.html
+++ b/storiesoflife/terms.html
@@ -31,11 +31,11 @@
       <div>
          <p>Link to privacy policy of third party service providers used by the app</p>
          <ul>
-            <li><a href="https://www.google.com/policies/privacy/" target="_blank">Google Play Services</a></li>
+            <li><a href="https://www.google.com/policies/privacy/" target="_blank" rel="noopener">Google Play Services</a></li>
             <!---->
-            <li><a href="https://firebase.google.com/policies/analytics" target="_blank">Firebase Analytics</a></li>
+            <li><a href="https://firebase.google.com/policies/analytics" target="_blank" rel="noopener">Firebase Analytics</a></li>
             <!----><!---->
-            <li><a href="http://try.crashlytics.com/terms/privacy-policy.pdf" target="_blank">Crashlytics</a></li>
+            <li><a href="http://try.crashlytics.com/terms/privacy-policy.pdf" target="_blank" rel="noopener">Crashlytics</a></li>
             <!----><!----><!---->
          </ul>
       </div>


### PR DESCRIPTION
The security vulnerability (missing `rel="noopener"` on `target="_blank"` links) was identified in `nightbear/memeapp/terms.html` and several other files. 

### 🎯 What
Added the `rel="noopener"` attribute to all `<a>` tags that use `target="_blank"`.

### ⚠️ Risk
Without `rel="noopener"`, a page opened in a new tab can access the original page via `window.opener`. A malicious site could use this to redirect the original tab to a phishing page or execute other malicious actions (Reverse Tabnabbing).

### 🛡️ Solution
Added `rel="noopener"` to all such links in the source files. This ensures the new page does not have access to the `window.opener` property, effectively neutralizing the threat.

Verified the fix across the entire codebase using `grep` and a Playwright verification script.

---
*PR created automatically by Jules for task [4392991418305656853](https://jules.google.com/task/4392991418305656853) started by @jacobceles*