### PR TITLE
⚡ Bolt: Add lazy loading to project images

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Add lazy loading to images
+**Learning:** Found several images in static HTML files without `loading="lazy"` attribute, which could delay page load.
+**Action:** Always verify `loading="lazy"` is used on `<img>` tags, especially those below the fold or generated from Jekyll data files.

--- a/_layouts/projects.html
+++ b/_layouts/projects.html
@@ -242,7 +242,8 @@
                <div class="wow animated fadeIn" data-wow-delay=".15s">
                   <div class="project card text-dark">
                      {%- if project_img -%}
-                     <img id="{{ project_name }}-img" class="card-img-top" src="{{ project_img }}" alt="{{ project_name }}" />
+                     <!-- ⚡ Bolt Optimization: Added loading="lazy" to defer offscreen images and reduce initial page load -->
+                     <img id="{{ project_name }}-img" class="card-img-top" src="{{ project_img }}" alt="{{ project_name }}" loading="lazy" />
                      {%- endif -%}
                      <div class="card-body">
                         <h4 id="{{ project_name }}-name" class="card-title">


### PR DESCRIPTION
💡 **What:** Added `loading="lazy"` to the `<img>` tags inside the project cards layout (`_layouts/projects.html`).
🎯 **Why:** To prevent loading all project images upfront on page load, which hurts initial performance, especially on a page with multiple images.
📊 **Impact:** Reduces initial page load time and saves bandwidth by deferring offscreen images until the user scrolls near them.
🔬 **Measurement:** Verify by loading the `Works` page and checking the network tab—images below the fold will only load as you scroll down.

---
*PR created automatically by Jules for task [3105003726243898578](https://jules.google.com/task/3105003726243898578) started by @jacobceles*