### PR TITLE
🎨 Palette: Add tooltips to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-03-14 - Redundant ARIA labels vs Title tooltips
+**Learning:** In the Hydejack theme layouts (e.g., `_layouts/projects.html`, `_layouts/education_skills.html`), icon-only buttons generally already contain `<span class="sr-only">` text for screen readers. Adding `aria-label` to these elements is redundant and may override intended text. Sighted mouse users, however, lack context.
+**Action:** Use `title` attributes on icon-only navigation elements (like `#_menu`, `#_forward`) that already have `.sr-only` inner text to provide native tooltips for sighted users without harming accessibility.

--- a/_layouts/education_skills.html
+++ b/_layouts/education_skills.html
@@ -83,7 +83,7 @@
          <div class="content">
             <div class="nav-btn-bar">
                <span class="sr-only">Jump to:</span>
-               <a id="_menu" class="nav-btn no-hover fl" href="#_navigation">
+               <a id="_menu" class="nav-btn no-hover fl" href="#_navigation" title="Navigation">
                <span class="sr-only">Navigation</span>
                <span class="icon-menu"></span>
                </a>
@@ -289,19 +289,19 @@
          </div>
       </template>
       <template id="_forward-template" hidden>
-         <button id="_forward" class="forward nav-btn no-hover fl">
+         <button id="_forward" class="forward nav-btn no-hover fl" title="Forward">
          <span class="sr-only">Forward</span>
          <span class="icon-arrow-right2"></span>
          </button>
       </template>
       <template id="_back-template" hidden>
-         <button id="_back" class="back nav-btn no-hover fl">
+         <button id="_back" class="back nav-btn no-hover fl" title="Back">
          <span class="sr-only">Back</span>
          <span class="icon-arrow-left2"></span>
          </button>
       </template>
       <template id="_permalink-template" hidden>
-         <a href="#" class="permalink">
+         <a href="#" class="permalink" title="Permalink">
          <span class="sr-only">Permalink</span>
          <span class="icon-link"></span>
          </a>

--- a/_layouts/experience.html
+++ b/_layouts/experience.html
@@ -83,7 +83,7 @@
          <div class="content">
             <div class="nav-btn-bar">
                <span class="sr-only">Jump to:</span>
-               <a id="_menu" class="nav-btn no-hover fl" href="#_navigation">
+               <a id="_menu" class="nav-btn no-hover fl" href="#_navigation" title="Navigation">
                <span class="sr-only">Navigation</span>
                <span class="icon-menu"></span>
                </a>
@@ -259,19 +259,19 @@
          </div>
       </template>
       <template id="_forward-template" hidden>
-         <button id="_forward" class="forward nav-btn no-hover fl">
+         <button id="_forward" class="forward nav-btn no-hover fl" title="Forward">
          <span class="sr-only">Forward</span>
          <span class="icon-arrow-right2"></span>
          </button>
       </template>
       <template id="_back-template" hidden>
-         <button id="_back" class="back nav-btn no-hover fl">
+         <button id="_back" class="back nav-btn no-hover fl" title="Back">
          <span class="sr-only">Back</span>
          <span class="icon-arrow-left2"></span>
          </button>
       </template>
       <template id="_permalink-template" hidden>
-         <a href="#" class="permalink">
+         <a href="#" class="permalink" title="Permalink">
          <span class="sr-only">Permalink</span>
          <span class="icon-link"></span>
          </a>

--- a/_layouts/projects.html
+++ b/_layouts/projects.html
@@ -100,7 +100,7 @@
          <div class="content">
             <div class="nav-btn-bar">
                <span class="sr-only">Jump to:</span>
-               <a id="_menu" class="nav-btn no-hover fl" href="#_navigation">
+               <a id="_menu" class="nav-btn no-hover fl" href="#_navigation" title="Navigation">
                <span class="sr-only">Navigation</span>
                <span class="icon-menu"></span>
                </a>
@@ -302,19 +302,19 @@
          </div>
       </template>
       <template id="_forward-template" hidden>
-         <button id="_forward" class="forward nav-btn no-hover fl">
+         <button id="_forward" class="forward nav-btn no-hover fl" title="Forward">
          <span class="sr-only">Forward</span>
          <span class="icon-arrow-right2"></span>
          </button>
       </template>
       <template id="_back-template" hidden>
-         <button id="_back" class="back nav-btn no-hover fl">
+         <button id="_back" class="back nav-btn no-hover fl" title="Back">
          <span class="sr-only">Back</span>
          <span class="icon-arrow-left2"></span>
          </button>
       </template>
       <template id="_permalink-template" hidden>
-         <a href="#" class="permalink">
+         <a href="#" class="permalink" title="Permalink">
          <span class="sr-only">Permalink</span>
          <span class="icon-link"></span>
          </a>


### PR DESCRIPTION
💡 What: Added `title` attributes to the `#_menu`, `#_forward`, `#_back`, and `.permalink` icon-only buttons in `_layouts/projects.html`, `_layouts/education_skills.html`, and `_layouts/experience.html`. Added a `.Jules/palette.md` to record the learning.
🎯 Why: While screen readers are served by existing `<span class="sr-only">` tags, sighted users navigating via mouse lack visual tooltips to quickly understand the function of these ambiguous icons. This adds a native hover tooltip.
📸 Before/After: N/A (Hover interaction change)
♿ Accessibility: Improves usability for sighted mouse users without overriding or degrading screen reader experiences.

---
*PR created automatically by Jules for task [3515182255253821770](https://jules.google.com/task/3515182255253821770) started by @jacobceles*