### PR TITLE
🧹 Remove commented out search form in layout templates

### DIFF
--- a/_layouts/education_skills.html
+++ b/_layouts/education_skills.html
@@ -87,18 +87,6 @@
                <span class="sr-only">Navigation</span>
                <span class="icon-menu"></span>
                </a>
-               <!-- <a id="_search" class="nav-btn no-hover fl" href="#_search">
-                  <span class="sr-only">Search</span>
-                  <span class="icon-search"></span>
-                  </a>
-                  <form action="https://duckduckgo.com/" method="GET">
-                  <div class="form-group fr">
-                    <label class="sr-only" for="_search">Search</label>
-                    <input id="_search" name="q" class="form-control" type="search" />
-                  </div>
-                  <input type="hidden" name="q" value="site:hydejack.com" />
-                  <input type="hidden" name="ia" value="web" />
-                  </form> -->
             </div>
          </div>
       </div>

--- a/_layouts/experience.html
+++ b/_layouts/experience.html
@@ -87,18 +87,6 @@
                <span class="sr-only">Navigation</span>
                <span class="icon-menu"></span>
                </a>
-               <!-- <a id="_search" class="nav-btn no-hover fl" href="#_search">
-                  <span class="sr-only">Search</span>
-                  <span class="icon-search"></span>
-                  </a>
-                  <form action="https://duckduckgo.com/" method="GET">
-                  <div class="form-group fr">
-                    <label class="sr-only" for="_search">Search</label>
-                    <input id="_search" name="q" class="form-control" type="search" />
-                  </div>
-                  <input type="hidden" name="q" value="site:hydejack.com" />
-                  <input type="hidden" name="ia" value="web" />
-                  </form> -->
             </div>
          </div>
       </div>

--- a/_layouts/projects.html
+++ b/_layouts/projects.html
@@ -104,18 +104,6 @@
                <span class="sr-only">Navigation</span>
                <span class="icon-menu"></span>
                </a>
-               <!-- <a id="_search" class="nav-btn no-hover fl" href="#_search">
-                  <span class="sr-only">Search</span>
-                  <span class="icon-search"></span>
-                  </a>
-                  <form action="https://duckduckgo.com/" method="GET">
-                  <div class="form-group fr">
-                    <label class="sr-only" for="_search">Search</label>
-                    <input id="_search" name="q" class="form-control" type="search" />
-                  </div>
-                  <input type="hidden" name="q" value="site:hydejack.com" />
-                  <input type="hidden" name="ia" value="web" />
-                  </form> -->
             </div>
          </div>
       </div>


### PR DESCRIPTION
🎯 **What:** Removed commented out search form from `_layouts/projects.html`, `_layouts/education_skills.html`, and `_layouts/experience.html`.

💡 **Why:** To remove dead code, improving the overall maintainability and readability of the layout templates.

✅ **Verification:** Ran `bundle exec jekyll build` to ensure the site generated successfully. Verified visually that there were no regressions.

✨ **Result:** A cleaner template file without any unnecessary, disabled HTML blocks.

---
*PR created automatically by Jules for task [10186072842090245669](https://jules.google.com/task/10186072842090245669) started by @jacobceles*