### PR TITLE
🎨 Palette: Fix incorrect aria-valuenow on skill progress bars

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-03-14 - Redundant ARIA labels vs Title tooltips
 **Learning:** In the Hydejack theme layouts (e.g., `_layouts/projects.html`, `_layouts/education_skills.html`), icon-only buttons generally already contain `<span class="sr-only">` text for screen readers. Adding `aria-label` to these elements is redundant and may override intended text. Sighted mouse users, however, lack context.
 **Action:** Use `title` attributes on icon-only navigation elements (like `#_menu`, `#_forward`) that already have `.sr-only` inner text to provide native tooltips for sighted users without harming accessibility.
+## 2024-03-14 - Dynamic ARIA attributes in templates
+**Learning:** Hardcoded ARIA attributes (like `aria-valuenow="60"`) in loop templates override dynamic visual representations, causing screen readers to announce incorrect information for every iterated item (e.g. 60% instead of 95%).
+**Action:** Always ensure ARIA attributes in dynamic components or loops reflect the actual data value using the templating engine syntax (e.g. `aria-valuenow="{{ skill.level | remove: '%' }}"`).

--- a/_layouts/education_skills.html
+++ b/_layouts/education_skills.html
@@ -230,7 +230,7 @@
                            <div class="progress-container progress-primary">
                               <span class="progress-badge">{{ skill.name }}</span>
                               <div class="progress">
-                                 <div class="progress-bar progress-bar-primary" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width:{{ skill.level }}"></div>
+                                 <div class="progress-bar progress-bar-primary" role="progressbar" aria-valuenow="{{ skill.level | remove: '%' }}" aria-valuemin="0" aria-valuemax="100" style="width:{{ skill.level }}"></div>
                                  <span class="progress-value">{{ skill.level }}</span>
                               </div>
                            </div>


### PR DESCRIPTION
🎨 Palette: Fix incorrect aria-valuenow on skill progress bars

💡 What: Updated the `aria-valuenow` attribute on skill progress bars in `_layouts/education_skills.html` to dynamically reflect the actual `skill.level` value using Liquid syntax, rather than being hardcoded to 60.

🎯 Why: The previous hardcoded `aria-valuenow="60"` caused screen readers to announce every skill as "60%" proficient, regardless of its actual value. This creates a confusing and incorrect accessibility experience.

♿ Accessibility: Ensures that screen reader users receive accurate information about the user's proficiency level in each skill.

---
*PR created automatically by Jules for task [14104090008411681844](https://jules.google.com/task/14104090008411681844) started by @jacobceles*