### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix missing SRI on CDN scripts

### DIFF
--- a/_layouts/projects.html
+++ b/_layouts/projects.html
@@ -61,7 +61,7 @@
       <link rel="dns-prefetch" href="/assets/bower_components/katex/dist/contrib/copy-tex.min.css" id="_hrefKatexCopyCSS">
       <link rel="dns-prefetch" href="/assets/img/swipe.svg" id="_hrefSwipeSVG">
       <!-- GitHub Buttons -->
-      <script type="text/javascript" async defer src="https://buttons.github.io/buttons.js"></script>
+      <script type="text/javascript" async defer src="https://unpkg.com/github-buttons@2.31.1/dist/buttons.min.js" integrity="sha384-XCI+GuqUCJpce+KtYuH4gdy5Z1+zy/wBXcs9CTuVHNZv3b1Bk8+/3H2r7NhOqVq2" crossorigin="anonymous"></script>
       <!-- jQuery CDN -->
       <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js" integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n" crossorigin="anonymous"></script>
       <!-- Popper.js CDN -->

--- a/knowledge_repo/colab_and_pyspark/index.html
+++ b/knowledge_repo/colab_and_pyspark/index.html
@@ -22,7 +22,7 @@
 
 <!-- Loading mathjax macro -->
 <!-- Load mathjax -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-AMS_HTML"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS_HTML" integrity="sha384-3lJUsx1TJHt7BA4udB5KPnDrlkO8T6J6v/op7ui0BbCjvZ9WqV4Xm6DTP6kQ/iBH" crossorigin="anonymous"></script>
     <!-- MathJax configuration -->
     <script type="text/x-mathjax-config">
     MathJax.Hub.Config({


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Unversioned external CDN scripts were loaded without `integrity` (SRI) and `crossorigin` attributes. If the CDN were compromised, malicious code could execute on the site. In addition, unversioned scripts could unexpectedly break the site if the provider ships breaking changes.
🎯 **Impact:** Prevents malicious code injection via compromised CDN dependencies.
🔧 **Fix:** Changed URLs to use strict, immutable versions (`@2.31.1` for GitHub buttons, `2.7.5/MathJax.js` for MathJax) and applied the calculated SHA-384 integrity hashes with `crossorigin="anonymous"`.
✅ **Verification:** Ran `bundle exec jekyll build` successfully and manually verified the SRI hashes and version URLs.

---
*PR created automatically by Jules for task [6848040070687058028](https://jules.google.com/task/6848040070687058028) started by @jacobceles*