### PR TITLE
🎨 Palette: Add aria-label to skill progress bars

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,7 @@
 ## 2024-03-14 - Dynamic ARIA attributes in templates
 **Learning:** Hardcoded ARIA attributes (like `aria-valuenow="60"`) in loop templates override dynamic visual representations, causing screen readers to announce incorrect information for every iterated item (e.g. 60% instead of 95%).
 **Action:** Always ensure ARIA attributes in dynamic components or loops reflect the actual data value using the templating engine syntax (e.g. `aria-valuenow="{{ skill.level | remove: '%' }}"`).
+
+## 2024-03-14 - Missing ARIA labels on progress bars
+**Learning:** Progress bars with `role="progressbar"` need an explicit `aria-label` or `aria-labelledby` to associate the progress with its subject (e.g., the skill name). Without it, screen readers only announce the value, lacking context.
+**Action:** Always add an `aria-label` referencing the relevant context (like `aria-label="{{ skill.name }} skill level"`) to `role="progressbar"` elements to ensure screen readers provide full context.

--- a/_layouts/education_skills.html
+++ b/_layouts/education_skills.html
@@ -230,7 +230,7 @@
                            <div class="progress-container progress-primary">
                               <span class="progress-badge">{{ skill.name }}</span>
                               <div class="progress">
-                                 <div class="progress-bar progress-bar-primary" role="progressbar" aria-valuenow="{{ skill.level | remove: '%' }}" aria-valuemin="0" aria-valuemax="100" style="width:{{ skill.level }}"></div>
+                                 <div class="progress-bar progress-bar-primary" role="progressbar" aria-label="{{ skill.name }} skill level" aria-valuenow="{{ skill.level | remove: '%' }}" aria-valuemin="0" aria-valuemax="100" style="width:{{ skill.level }}"></div>
                                  <span class="progress-value">{{ skill.level }}</span>
                               </div>
                            </div>


### PR DESCRIPTION
💡 **What:** Added an `aria-label` attribute to the `role="progressbar"` elements in `_layouts/education_skills.html`.
🎯 **Why:** To improve accessibility for screen reader users by explicitly associating the progress value with the corresponding skill name (e.g., "Python skill level"). Previously, the progress bar only announced its numerical value, lacking context about what skill it represented.
♿ **Accessibility:** Enhances screen reader context by providing an explicit descriptive label for progress bars.

---
*PR created automatically by Jules for task [15220687577104677221](https://jules.google.com/task/15220687577104677221) started by @jacobceles*