### PR TITLE
🛡️ Sentinel: [HIGH] Restrict overly permissive Content-Security-Policy

### DIFF
--- a/knowledge_repo/colab_and_pyspark/index.html
+++ b/knowledge_repo/colab_and_pyspark/index.html
@@ -3,7 +3,7 @@
 <head>
 
 <meta charset="utf-8" />
-<meta http-equiv="Content-Security-Policy" content="default-src * self blob: data: gap:; style-src * self 'unsafe-inline' blob: data: gap:; script-src * 'self' 'unsafe-eval' 'unsafe-inline' blob: data: gap:; object-src * 'self' blob: data: gap:; img-src * self 'unsafe-inline' blob: data: gap:; connect-src self * 'unsafe-inline' blob: data: gap:; frame-src * self blob: data: gap:;">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self' blob: data: gap:; style-src 'self' 'unsafe-inline' blob: data: gap:; script-src 'self' 'unsafe-eval' 'unsafe-inline' https://cdnjs.cloudflare.com blob: data: gap:; object-src 'self' blob: data: gap:; img-src 'self' 'unsafe-inline' https://jacobcelestine.com https://2s7gjr373w3x22jf92z99mgm5w-wpengine.netdna-ssl.com blob: data: gap:; connect-src 'self' 'unsafe-inline' blob: data: gap:; frame-src 'self' blob: data: gap:;">
 <meta prefix="og: https://ogp.me/ns#" property="og:url" content="https://jacobcelestine.com/knowledge_repo/colab_and_pyspark/"/>
 <meta prefix="og: https://ogp.me/ns#" property="og:type" content="article"/>
 <meta prefix="og: https://ogp.me/ns#" property="og:title" content="Introduction to Google Colab, PySpark and EC2 Instances"/>


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `knowledge_repo/colab_and_pyspark/index.html` file had an overly permissive Content-Security-Policy (`default-src *`) which allowed loading resources from any domain, defeating the purpose of a CSP and leaving the page vulnerable to Cross-Site Scripting (XSS) and data exfiltration.
🎯 Impact: An attacker could potentially inject malicious scripts or images, or load unauthorized frames, since the wildcards would permit it.
🔧 Fix: Tightened the CSP to use `default-src 'self'` and specifically whitelisted the required CDNs for MathJax/jQuery (`https://cdnjs.cloudflare.com`) and external images (`https://jacobcelestine.com`, `https://2s7gjr373w3x22jf92z99mgm5w-wpengine.netdna-ssl.com`).
✅ Verification: Tested the page locally using a Playwright script to verify the CSP was enforced without breaking the CSS rendering or script functionality. Also verified the Jekyll site builds cleanly.

---
*PR created automatically by Jules for task [10647436139145753635](https://jules.google.com/task/10647436139145753635) started by @jacobceles*