### PR TITLE
🎨 Palette: Add aria-current to active sidebar navigation links

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,7 @@
 ## 2024-03-14 - Missing ARIA labels on progress bars
 **Learning:** Progress bars with `role="progressbar"` need an explicit `aria-label` or `aria-labelledby` to associate the progress with its subject (e.g., the skill name). Without it, screen readers only announce the value, lacking context.
 **Action:** Always add an `aria-label` referencing the relevant context (like `aria-label="{{ skill.name }} skill level"`) to `role="progressbar"` elements to ensure screen readers provide full context.
+
+## 2026-03-18 - Add aria-current for active links in custom Jekyll layouts
+**Learning:** Hardcoded sidebar navigation menus in custom standalone Jekyll layouts do not automatically receive `aria-current="page"` attributes to indicate the active state to screen readers.
+**Action:** Always add `{% if page.url == '/your_path/' %}aria-current="page"{% endif %}` to navigation links in custom Jekyll layouts to ensure screen readers can identify the current active page.

--- a/_layouts/education_skills.html
+++ b/_layouts/education_skills.html
@@ -125,6 +125,7 @@
                               id="_navigation"
                               href="/education_skills/"
                               class="sidebar-nav-item"
+                              {% if page.url == '/education_skills/' %}aria-current="page"{% endif %}
                               >
                            Education & Skills
                            </a>
@@ -134,6 +135,7 @@
                               id="_navigation"
                               href="/experience/"
                               class="sidebar-nav-item"
+                              {% if page.url == '/experience/' %}aria-current="page"{% endif %}
                               >
                            Experience
                            </a>
@@ -143,6 +145,7 @@
                               id="_navigation"
                               href="/projects/"
                               class="sidebar-nav-item"
+                              {% if page.url == '/projects/' %}aria-current="page"{% endif %}
                               >
                            Works
                            </a>

--- a/_layouts/experience.html
+++ b/_layouts/experience.html
@@ -125,6 +125,7 @@
                               id="_navigation"
                               href="/education_skills/"
                               class="sidebar-nav-item"
+                              {% if page.url == '/education_skills/' %}aria-current="page"{% endif %}
                               >
                            Education & Skills
                            </a>
@@ -134,6 +135,7 @@
                               id="_navigation"
                               href="/experience/"
                               class="sidebar-nav-item"
+                              {% if page.url == '/experience/' %}aria-current="page"{% endif %}
                               >
                            Experience
                            </a>
@@ -143,6 +145,7 @@
                               id="_navigation"
                               href="/projects/"
                               class="sidebar-nav-item"
+                              {% if page.url == '/projects/' %}aria-current="page"{% endif %}
                               >
                            Works
                            </a>

--- a/_layouts/projects.html
+++ b/_layouts/projects.html
@@ -149,6 +149,7 @@
                               id="_navigation"
                               href="/education_skills/"
                               class="sidebar-nav-item"
+                              {% if page.url == '/education_skills/' %}aria-current="page"{% endif %}
                               >
                            Education & Skills
                            </a>
@@ -158,6 +159,7 @@
                               id="_navigation"
                               href="/experience/"
                               class="sidebar-nav-item"
+                              {% if page.url == '/experience/' %}aria-current="page"{% endif %}
                               >
                            Experience
                            </a>
@@ -167,6 +169,7 @@
                               id="_navigation"
                               href="/projects/"
                               class="sidebar-nav-item"
+                              {% if page.url == '/projects/' %}aria-current="page"{% endif %}
                               >
                            Works
                            </a>


### PR DESCRIPTION
🎯 **What:** 
Added the `aria-current="page"` attribute to the sidebar navigation links in the custom Jekyll layout files (`_layouts/education_skills.html`, `_layouts/experience.html`, and `_layouts/projects.html`). This is dynamically applied when `page.url` matches the link's `href` via Jekyll liquid tags.

💡 **Why:**
In the custom hardcoded navigation sidebar in these layout files, the active navigation item was visually implied by context, but screen readers were unable to programmatically determine which link represented the current page. Providing `aria-current="page"` explicitly gives context and improves overall accessibility without affecting CSS layout or colors.

♿ **Accessibility:**
- Added `aria-current="page"` correctly for the active link in the navigation menu, following best practices for a11y.

📸 **Before/After:**
*(No visual changes - purely a programmatic semantic enhancement for screen readers.)*

**Journaled:**
Added entry to `.Jules/palette.md` noting the importance of manually attaching active state aria labels to hardcoded navigation menus in Jekyll custom layouts.

---
*PR created automatically by Jules for task [9541078551834712146](https://jules.google.com/task/9541078551834712146) started by @jacobceles*