### PR TITLE
⚡ Bolt: Add preconnect resource hints for Google Fonts

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-24 - Add lazy loading to images
 **Learning:** Found several images in static HTML files without `loading="lazy"` attribute, which could delay page load.
 **Action:** Always verify `loading="lazy"` is used on `<img>` tags, especially those below the fold or generated from Jekyll data files.
+## 2024-03-18 - Improve font loading performance with preconnect
+**Learning:** Adding `preconnect` resource hints for Google Fonts origins alongside `dns-prefetch` can significantly reduce layout shift and time-to-interactive by resolving DNS, TCP, and TLS early.
+**Action:** When working on performance, consider preconnecting to critical external domains to optimize the critical rendering path.

--- a/_layouts/education_skills.html
+++ b/_layouts/education_skills.html
@@ -51,6 +51,9 @@
       <link rel="manifest" href="/assets/manifest.json">
       <link rel="dns-prefetch" href="https://fonts.googleapis.com">
       <link rel="dns-prefetch" href="https://fonts.gstatic.com">
+      <!-- ⚡ Bolt Optimization: Add preconnect for critical Google Fonts origins -->
+      <link rel="preconnect" href="https://fonts.googleapis.com">
+      <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
       <link rel="dns-prefetch" href="/" id="_baseURL">
       <link rel="dns-prefetch" href="/assets/js/hydejack-legacy-8.5.0.js" id="_hrefJS">
       <link rel="dns-prefetch" href="/sw.js" id="_hrefSW">

--- a/_layouts/experience.html
+++ b/_layouts/experience.html
@@ -51,6 +51,9 @@
       <link rel="manifest" href="/assets/manifest.json">
       <link rel="dns-prefetch" href="https://fonts.googleapis.com">
       <link rel="dns-prefetch" href="https://fonts.gstatic.com">
+      <!-- ⚡ Bolt Optimization: Add preconnect for critical Google Fonts origins -->
+      <link rel="preconnect" href="https://fonts.googleapis.com">
+      <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
       <link rel="dns-prefetch" href="/" id="_baseURL">
       <link rel="dns-prefetch" href="/assets/js/hydejack-legacy-8.5.0.js" id="_hrefJS">
       <link rel="dns-prefetch" href="/sw.js" id="_hrefSW">

--- a/_layouts/projects.html
+++ b/_layouts/projects.html
@@ -51,6 +51,9 @@
       <link rel="manifest" href="/assets/manifest.json">
       <link rel="dns-prefetch" href="https://fonts.googleapis.com">
       <link rel="dns-prefetch" href="https://fonts.gstatic.com">
+      <!-- ⚡ Bolt Optimization: Add preconnect for critical Google Fonts origins -->
+      <link rel="preconnect" href="https://fonts.googleapis.com">
+      <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
       <link rel="dns-prefetch" href="/" id="_baseURL">
       <link rel="dns-prefetch" href="/assets/js/hydejack-legacy-8.5.0.js" id="_hrefJS">
       <link rel="dns-prefetch" href="/sw.js" id="_hrefSW">


### PR DESCRIPTION
💡 **What:**
Added `<link rel="preconnect">` tags for `https://fonts.googleapis.com` and `https://fonts.gstatic.com` (with `crossorigin`) to the `_layouts/education_skills.html`, `_layouts/experience.html`, and `_layouts/projects.html` files.

🎯 **Why:**
The site was relying on `dns-prefetch` for Google Fonts origins. Upgrading to or supplementing with `preconnect` tells the browser to aggressively initiate an early connection, which includes not just the DNS lookup, but also the TCP handshake and TLS negotiation. This shaves off critical round-trip times during the rendering path before the CSS actually requests the fonts. It prevents rendering delays, speeding up First Contentful Paint (FCP) and potentially mitigating Cumulative Layout Shift (CLS).

📊 **Impact:**
Establishing an early connection for font resources typically saves 50–200ms of loading time in standard network scenarios and can have a noticeable impact on mobile connection latencies, making the site feel significantly snappier.

🔬 **Measurement:**
This can be verified by observing the browser DevTools "Network" tab, specifically looking at the connection timing details (DNS, Connect, SSL) for requests made to the `fonts.googleapis.com` and `fonts.gstatic.com` domains. The connection should already be established by the time the browser requests the CSS and font files.

---
*PR created automatically by Jules for task [17379805054121637066](https://jules.google.com/task/17379805054121637066) started by @jacobceles*