### PR TITLE
⚡ Bolt: Preload LCP images and remove lazy loading from above-the-fold images

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,7 @@
 ## 2024-03-18 - Improve font loading performance with preconnect
 **Learning:** Adding `preconnect` resource hints for Google Fonts origins alongside `dns-prefetch` can significantly reduce layout shift and time-to-interactive by resolving DNS, TCP, and TLS early.
 **Action:** When working on performance, consider preconnecting to critical external domains to optimize the critical rendering path.
+
+## 2024-10-26 - Preloading LCP images and removing lazy loading from above-the-fold
+**Learning:** Adding `loading="lazy"` to above-the-fold images is a performance anti-pattern that delays the Largest Contentful Paint (LCP) and render time because the browser has to wait for layout to know if the image is visible. Preloading critical LCP images (like sidebar backgrounds and profile icons) using `<link rel="preload" as="image">` improves LCP.
+**Action:** Never lazy-load above-the-fold images. Always evaluate whether an image is above the fold, and preload it if it's a critical LCP element.

--- a/_layouts/education_skills.html
+++ b/_layouts/education_skills.html
@@ -64,6 +64,9 @@
       <link rel="dns-prefetch" href="/assets/bower_components/katex/dist/contrib/copy-tex.min.js" id="_hrefKatexCopyJS">
       <link rel="dns-prefetch" href="/assets/bower_components/katex/dist/contrib/copy-tex.min.css" id="_hrefKatexCopyCSS">
       <link rel="dns-prefetch" href="/assets/img/swipe.svg" id="_hrefSwipeSVG">
+      <!-- ⚡ Bolt Optimization: Preload LCP images -->
+      <link rel="preload" as="image" href="/assets/img/sidebar-bg.jpg">
+      <link rel="preload" as="image" href="/assets/icons/profile_icon.png">
       <script>
          !function(e,t){"use strict";function n(e,t,n,r){e.addEventListener?e.addEventListener(t,n,r):e.attachEvent?e.attachEvent("on"+t,n):e["on"+t]=n}e.loadJS=function(e,r){var o=t.createElement("script");o.src=e,r&&n(o,"load",r,{once:!0});var a=t.scripts[0];return a.parentNode.insertBefore(o,a),o},e._loaded=!1,e.loadJSDeferred=function(r,o){function a(){e._loaded=!0,o&&n(d,"load",o,{once:!0});var r=t.scripts[0];r.parentNode.insertBefore(d,r)}var d=t.createElement("script");return d.src=r,e._loaded?a():n(e,"load",a,{once:!0}),d},e.setRel=e.setRelStylesheet=function(e){function n(){this.rel="stylesheet"}var r=t.getElementById(e);r.addEventListener?r.addEventListener("load",n,{once:!0}):r.onload=n}}(window,document);
          
@@ -114,7 +117,8 @@
                <div class="sidebar-sticky">
                   <div class="sidebar-about">
                      <a class="no-hover" href="/" tabindex="-1">
-                     <img src="/assets/icons/profile_icon.png" class="avatar" alt="Jacob Celestine" loading="lazy" data-ignore />
+                     <!-- ⚡ Bolt Optimization: Removed lazy loading from above-the-fold image -->
+                     <img src="/assets/icons/profile_icon.png" class="avatar" alt="Jacob Celestine" data-ignore />
                      </a>
                      <h2 class="h1"><a href="/">Jacob Celestine</a></h2>
                      <p class="">

--- a/_layouts/experience.html
+++ b/_layouts/experience.html
@@ -64,6 +64,9 @@
       <link rel="dns-prefetch" href="/assets/bower_components/katex/dist/contrib/copy-tex.min.js" id="_hrefKatexCopyJS">
       <link rel="dns-prefetch" href="/assets/bower_components/katex/dist/contrib/copy-tex.min.css" id="_hrefKatexCopyCSS">
       <link rel="dns-prefetch" href="/assets/img/swipe.svg" id="_hrefSwipeSVG">
+      <!-- ⚡ Bolt Optimization: Preload LCP images -->
+      <link rel="preload" as="image" href="/assets/img/sidebar-bg.jpg">
+      <link rel="preload" as="image" href="/assets/icons/profile_icon.png">
       <script>
          !function(e,t){"use strict";function n(e,t,n,r){e.addEventListener?e.addEventListener(t,n,r):e.attachEvent?e.attachEvent("on"+t,n):e["on"+t]=n}e.loadJS=function(e,r){var o=t.createElement("script");o.src=e,r&&n(o,"load",r,{once:!0});var a=t.scripts[0];return a.parentNode.insertBefore(o,a),o},e._loaded=!1,e.loadJSDeferred=function(r,o){function a(){e._loaded=!0,o&&n(d,"load",o,{once:!0});var r=t.scripts[0];r.parentNode.insertBefore(d,r)}var d=t.createElement("script");return d.src=r,e._loaded?a():n(e,"load",a,{once:!0}),d},e.setRel=e.setRelStylesheet=function(e){function n(){this.rel="stylesheet"}var r=t.getElementById(e);r.addEventListener?r.addEventListener("load",n,{once:!0}):r.onload=n}}(window,document);
          
@@ -114,7 +117,8 @@
                <div class="sidebar-sticky">
                   <div class="sidebar-about">
                      <a class="no-hover" href="/" tabindex="-1">
-                     <img src="/assets/icons/profile_icon.png" class="avatar" alt="Jacob Celestine" loading="lazy" data-ignore />
+                     <!-- ⚡ Bolt Optimization: Removed lazy loading from above-the-fold image -->
+                     <img src="/assets/icons/profile_icon.png" class="avatar" alt="Jacob Celestine" data-ignore />
                      </a>
                      <h2 class="h1"><a href="/">Jacob Celestine</a></h2>
                      <p class="">

--- a/_layouts/projects.html
+++ b/_layouts/projects.html
@@ -64,6 +64,9 @@
       <link rel="dns-prefetch" href="/assets/bower_components/katex/dist/contrib/copy-tex.min.js" id="_hrefKatexCopyJS">
       <link rel="dns-prefetch" href="/assets/bower_components/katex/dist/contrib/copy-tex.min.css" id="_hrefKatexCopyCSS">
       <link rel="dns-prefetch" href="/assets/img/swipe.svg" id="_hrefSwipeSVG">
+      <!-- ⚡ Bolt Optimization: Preload LCP images -->
+      <link rel="preload" as="image" href="/assets/img/sidebar-bg.jpg">
+      <link rel="preload" as="image" href="/assets/icons/profile_icon.png">
       <!-- GitHub Buttons -->
       <script type="text/javascript" async defer src="https://unpkg.com/github-buttons@2.31.1/dist/buttons.min.js" integrity="sha384-XCI+GuqUCJpce+KtYuH4gdy5Z1+zy/wBXcs9CTuVHNZv3b1Bk8+/3H2r7NhOqVq2" crossorigin="anonymous"></script>
       <!-- ⚡ Bolt Optimization: Added defer to non-critical scripts to unblock main thread -->
@@ -138,7 +141,8 @@
                <div class="sidebar-sticky">
                   <div class="sidebar-about">
                      <a class="no-hover" href="/" tabindex="-1">
-                     <img src="/assets/icons/profile_icon.png" class="avatar" alt="Jacob Celestine" loading="lazy" data-ignore />
+                     <!-- ⚡ Bolt Optimization: Removed lazy loading from above-the-fold image -->
+                     <img src="/assets/icons/profile_icon.png" class="avatar" alt="Jacob Celestine" data-ignore />
                      </a>
                      <h2 class="h1"><a href="/">Jacob Celestine</a></h2>
                      <p class="">


### PR DESCRIPTION
💡 **What:** 
- Added `<link rel="preload" as="image">` hints for the critical above-the-fold images (`/assets/img/sidebar-bg.jpg` and `/assets/icons/profile_icon.png`).
- Removed the `loading="lazy"` attribute from the profile icon (`/assets/icons/profile_icon.png`) in the sidebar, which is visible immediately upon page load.
- Modified `_layouts/projects.html`, `_layouts/education_skills.html`, and `_layouts/experience.html`.
- Added a learnings entry to `.jules/bolt.md`.

🎯 **Why:** 
Lazy-loading images that are above the fold is a well-known performance anti-pattern. The browser must wait until layout is complete to determine if the image is in the viewport, which delays the image fetch and harms the Largest Contentful Paint (LCP) metric. Preloading these critical images directly in the `<head>` tells the browser to start fetching them immediately, resolving the bottleneck early in the critical rendering path.

📊 **Impact:** 
Expected to significantly improve the Largest Contentful Paint (LCP) time and reduce the Speed Index by fetching the heaviest visible assets concurrently with the document parsing, rather than waiting for layout calculations.

🔬 **Measurement:** 
Run Lighthouse or WebPageTest against the pages (e.g., `/projects/`, `/experience/`) and compare LCP metrics before and after the change. Ensure no "preload warnings" appear in the browser console.

---
*PR created automatically by Jules for task [12687027503121439402](https://jules.google.com/task/12687027503121439402) started by @jacobceles*