### PR TITLE
🧹 [code health] Remove empty HTML comments from terms.html

### DIFF
--- a/microstories/terms.html
+++ b/microstories/terms.html
@@ -32,11 +32,8 @@
          <p>Link to privacy policy of third party service providers used by the app</p>
          <ul>
             <li><a href="https://www.google.com/policies/privacy/" target="_blank" rel="noopener noreferrer">Google Play Services</a></li>
-            <!---->
             <li><a href="https://firebase.google.com/policies/analytics" target="_blank" rel="noopener noreferrer">Firebase Analytics</a></li>
-            <!----><!---->
             <li><a href="https://try.crashlytics.com/terms/privacy-policy.pdf" target="_blank" rel="noopener noreferrer">Crashlytics</a></li>
-            <!----><!----><!---->
          </ul>
       </div>
       <p><strong>Log Data</strong></p>


### PR DESCRIPTION
🎯 **What:** Removed empty HTML comments from `microstories/terms.html`.
💡 **Why:** Empty comments clutter the source code without providing any value or context, reducing readability. Removing them makes the file cleaner.
✅ **Verification:** Verified by building the site with Jekyll and ensuring no unintended behavior or layout shifts occurred.
✨ **Result:** Improved code cleanliness in `microstories/terms.html`.

---
*PR created automatically by Jules for task [12294244067140263443](https://jules.google.com/task/12294244067140263443) started by @jacobceles*