### PR TITLE
🧹 [Code Health] Remove empty href attribute from error template

### DIFF
--- a/_layouts/custom_base.html
+++ b/_layouts/custom_base.html
@@ -267,7 +267,7 @@
          <div class="page">
             <h1 class="page-title">Error</h1>
             <p class="lead">
-               Sorry, an error occurred while loading <a class="this-link" href=""></a>.
+               Sorry, an error occurred while loading <a class="this-link"></a>.
             </p>
          </div>
       </template>


### PR DESCRIPTION
🎯 **What:** Removed the empty `href=""` attribute from the anchor tag in the `_error-template` template within `_layouts/custom_base.html`.
💡 **Why:** According to the HTML5 specification, an `<a>` element without an `href` attribute is a perfectly valid placeholder for a link. Having an empty `href=""` is an anti-pattern that triggers HTML validation and linting warnings, and clicking an empty `href` reloads the page. Removing the attribute resolves the code health issue while preserving functionality, since the Javascript logic dynamically injects the correct URL via `i.href = r`.
✅ **Verification:** Verified that the site successfully builds using `bundle exec jekyll build` and captured a screenshot demonstrating that the frontend 404 page displays correctly. Also passed code review confirming the change is safe and introduces no regressions.
✨ **Result:** Improved HTML validity and code health in `_layouts/custom_base.html` without changing the application's behavior.

---
*PR created automatically by Jules for task [9861255064947539246](https://jules.google.com/task/9861255064947539246) started by @jacobceles*