### PR TITLE
🔒 Sentinel: High Fix insecure Content Security Policy (unsafe-inline)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Found previously-noted HTTP external links, however upon investigation, the repository's source files (layouts, markdown, yml) had already mitigated or upgraded them to HTTPS. Missing Content-Security-Policy allowed potential execution of unauthorized scripts.
 **Learning:** Sometimes build artifacts (`_site/`) or binaries can retain older HTTP links, but the source truth is what matters. A permissive CSP with `unsafe-inline` might be necessary for Jekyll themes like Hydejack without extensive refactoring.
 **Prevention:** Always verify links in the actual source code (`grep --exclude-dir=_site`) before attempting to upgrade, and use a strong CSP in base layout `<head>` tags.
+
+## 2026-05-01 - Insecure Content Security Policy (unsafe-inline)
+**Vulnerability:** The Content Security Policy (CSP) allowed 'unsafe-inline' for scripts and styles, rendering the site vulnerable to Cross-Site Scripting (XSS) attacks.
+**Learning:** Refactoring inline scripts and styles that contain Jekyll Liquid variables (e.g. `{{ site.accent_image }}`) requires them to be extracted into `.scss` files with frontmatter (`--- \n ---`) to enable Jekyll processing, while pure JavaScript should be moved to separate `.js` files and included using the `defer` attribute.
+**Prevention:** Avoid using `'unsafe-inline'` in `script-src` and `style-src` directives. Consistently utilize external CSS/JS assets, relying on build systems like Jekyll to dynamically process configuration variables.

--- a/_layouts/custom_base.html
+++ b/_layouts/custom_base.html
@@ -17,7 +17,7 @@
       <meta charset="utf-8">
       <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
       <meta http-equiv="x-ua-compatible" content="ie=edge">
-      <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://unpkg.com https://code.jquery.com https://cdn.jsdelivr.net https://stackpath.bootstrapcdn.com https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https://github.com; connect-src 'self'; object-src 'none'; frame-src 'self';">
+      <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-eval' https://unpkg.com https://code.jquery.com https://cdn.jsdelivr.net https://stackpath.bootstrapcdn.com https://cdnjs.cloudflare.com; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https://github.com; connect-src 'self'; object-src 'none'; frame-src 'self';">
       <!-- ⚡ Bolt Optimization: Preload critical LCP images to improve performance -->
       <link rel="preload" as="image" href="{{ site.accent_image }}" fetchpriority="high">
       <link rel="preload" as="image" href="{{ site.logo }}" fetchpriority="high">
@@ -73,21 +73,11 @@
       <link rel="dns-prefetch" href="/assets/bower_components/katex/dist/contrib/copy-tex.min.js" id="_hrefKatexCopyJS">
       <link rel="dns-prefetch" href="/assets/bower_components/katex/dist/contrib/copy-tex.min.css" id="_hrefKatexCopyCSS">
       <link rel="dns-prefetch" href="/assets/img/swipe.svg" id="_hrefSwipeSVG">
-      <script>
-         !function(e,t){"use strict";function n(e,t,n,r){e.addEventListener?e.addEventListener(t,n,r):e.attachEvent?e.attachEvent("on"+t,n):e["on"+t]=n}e.loadJS=function(e,r){var o=t.createElement("script");o.src=e,r&&n(o,"load",r,{once:!0});var a=t.scripts[0];return a.parentNode.insertBefore(o,a),o},e._loaded=!1,e.loadJSDeferred=function(r,o){function a(){e._loaded=!0,o&&n(d,"load",o,{once:!0});var r=t.scripts[0];r.parentNode.insertBefore(d,r)}var d=t.createElement("script");return d.src=r,e._loaded?a():n(e,"load",a,{once:!0}),d},e.setRel=e.setRelStylesheet=function(e){function n(){this.rel="stylesheet"}var r=t.getElementById(e);r.addEventListener?r.addEventListener("load",n,{once:!0}):r.onload=n}}(window,document);
-
-         !function(a){"use strict";var b=function(b,c,d){function e(a){return h.body?a():void setTimeout(function(){e(a)})}function f(){i.addEventListener&&i.removeEventListener("load",f),i.media=d||"all"}var g,h=a.document,i=h.createElement("link");if(c)g=c;else{var j=(h.body||h.getElementsByTagName("head")[0]).childNodes;g=j[j.length-1]}var k=h.styleSheets;i.rel="stylesheet",i.href=b,i.media="only x",e(function(){g.parentNode.insertBefore(i,c?g:g.nextSibling)});var l=function(a){for(var b=i.href,c=k.length;c--;)if(k[c].href===b)return a();setTimeout(function(){l(a)})};return i.addEventListener&&i.addEventListener("load",f),i.onloadcssdefined=l,l(f),i};"undefined"!=typeof exports?exports.loadCSS=b:a.loadCSS=b}("undefined"!=typeof global?global:this);
-
-         !function(a){if(a.loadCSS){var b=loadCSS.relpreload={};if(b.support=function(){try{return a.document.createElement("link").relList.supports("preload")}catch(b){return!1}},b.poly=function(){for(var b=a.document.getElementsByTagName("link"),c=0;c<b.length;c++){var d=b[c];"preload"===d.rel&&"style"===d.getAttribute("as")&&(a.loadCSS(d.href,d,d.getAttribute("media")),d.rel=null)}},!b.support()){b.poly();var c=a.setInterval(b.poly,300);a.addEventListener&&a.addEventListener("load",function(){b.poly(),a.clearInterval(c)}),a.attachEvent&&a.attachEvent("onload",function(){a.clearInterval(c)})}}}(this);
-
-         !function(w, d) {
-           w._noPushState = false;
-           w._noDrawer = false;
-         }(window, document);
-      </script>
+      <script defer src="/assets/js/setup.js"></script>
       <!--[if gt IE 8]><!---->
       <link rel="stylesheet" href="/assets/css/hydejack-8.5.0.css">
       <link rel="stylesheet" href="/assets/icomoon/style.css">
+      <link rel="stylesheet" href="{{ '/assets/css/custom_style.css' | relative_url }}">
       <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Slab:400|Noto+Sans:400,400i,700,700i&display=swap">
       <!--<![endif]-->
       {% if page.layout == 'projects' %}
@@ -102,19 +92,7 @@
       <script defer src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
       <!-- wow.js CDN & Activation -->
       <script defer src="https://cdnjs.cloudflare.com/ajax/libs/wow/1.1.2/wow.js" integrity="sha384-0U4AzjZUo6VJb79tvm16vwxZULsWzPJUqwNL8ZF/gonzLtsZen/jGg3CpYd//S2O" crossorigin="anonymous"></script>
-      <script>
-         window.addEventListener('DOMContentLoaded', function() {
-            new WOW().init();
-         });
-      </script>
-      <!-- Initialize all tooltips -->
-      <script>
-         window.addEventListener('DOMContentLoaded', function() {
-            $(function () {
-                $('[data-toggle="tooltip"]').tooltip()
-            })
-         });
-      </script>
+      <script defer src="/assets/js/wow-init.js"></script>
       {% endif %}
    </head>
    <body class="no-color-transition">
@@ -145,7 +123,7 @@
             prevent-default
             >
             <header id="_sidebar" class="sidebar" role="banner">
-               <div class="sidebar-bg sidebar-overlay" style="background-color:rgb(25,55,71);background-image:url({{ site.accent_image }})"></div>
+               <div class="sidebar-bg sidebar-overlay"></div>
                <div class="sidebar-sticky">
                   <div class="sidebar-about">
                      <a class="no-hover" href="/" tabindex="-1">

--- a/assets/css/custom_style.scss
+++ b/assets/css/custom_style.scss
@@ -1,0 +1,3 @@
+---
+---
+.sidebar-bg.sidebar-overlay { background-color: rgb(25, 55, 71); background-image: url('{{ site.accent_image }}'); }

--- a/assets/js/setup.js
+++ b/assets/js/setup.js
@@ -1,0 +1,10 @@
+!function(e,t){"use strict";function n(e,t,n,r){e.addEventListener?e.addEventListener(t,n,r):e.attachEvent?e.attachEvent("on"+t,n):e["on"+t]=n}e.loadJS=function(e,r){var o=t.createElement("script");o.src=e,r&&n(o,"load",r,{once:!0});var a=t.scripts[0];return a.parentNode.insertBefore(o,a),o},e._loaded=!1,e.loadJSDeferred=function(r,o){function a(){e._loaded=!0,o&&n(d,"load",o,{once:!0});var r=t.scripts[0];r.parentNode.insertBefore(d,r)}var d=t.createElement("script");return d.src=r,e._loaded?a():n(e,"load",a,{once:!0}),d},e.setRel=e.setRelStylesheet=function(e){function n(){this.rel="stylesheet"}var r=t.getElementById(e);r.addEventListener?r.addEventListener("load",n,{once:!0}):r.onload=n}}(window,document);
+
+!function(a){"use strict";var b=function(b,c,d){function e(a){return h.body?a():void setTimeout(function(){e(a)})}function f(){i.addEventListener&&i.removeEventListener("load",f),i.media=d||"all"}var g,h=a.document,i=h.createElement("link");if(c)g=c;else{var j=(h.body||h.getElementsByTagName("head")[0]).childNodes;g=j[j.length-1]}var k=h.styleSheets;i.rel="stylesheet",i.href=b,i.media="only x",e(function(){g.parentNode.insertBefore(i,c?g:g.nextSibling)});var l=function(a){for(var b=i.href,c=k.length;c--;)if(k[c].href===b)return a();setTimeout(function(){l(a)})};return i.addEventListener&&i.addEventListener("load",f),i.onloadcssdefined=l,l(f),i};"undefined"!=typeof exports?exports.loadCSS=b:a.loadCSS=b}("undefined"!=typeof global?global:this);
+
+!function(a){if(a.loadCSS){var b=loadCSS.relpreload={};if(b.support=function(){try{return a.document.createElement("link").relList.supports("preload")}catch(b){return!1}},b.poly=function(){for(var b=a.document.getElementsByTagName("link"),c=0;c<b.length;c++){var d=b[c];"preload"===d.rel&&"style"===d.getAttribute("as")&&(a.loadCSS(d.href,d,d.getAttribute("media")),d.rel=null)}},!b.support()){b.poly();var c=a.setInterval(b.poly,300);a.addEventListener&&a.addEventListener("load",function(){b.poly(),a.clearInterval(c)}),a.attachEvent&&a.attachEvent("onload",function(){a.clearInterval(c)})}}}(this);
+
+!function(w, d) {
+  w._noPushState = false;
+  w._noDrawer = false;
+}(window, document);

--- a/assets/js/wow-init.js
+++ b/assets/js/wow-init.js
@@ -1,0 +1,8 @@
+window.addEventListener('DOMContentLoaded', function() {
+    new WOW().init();
+});
+window.addEventListener('DOMContentLoaded', function() {
+    $(function () {
+        $('[data-toggle="tooltip"]').tooltip()
+    })
+});


### PR DESCRIPTION
🎯 **What:** The Content-Security-Policy in `_layouts/custom_base.html` contained the `'unsafe-inline'` directive for both `script-src` and `style-src`. This allowed inline scripts and styles to execute, creating a security vulnerability. The fix involved extracting these inline elements out to separate `.js` and `.scss` files and subsequently removing `'unsafe-inline'` from the CSP.

⚠️ **Risk:** Including `'unsafe-inline'` heavily weakens the Content Security Policy, making the website much more susceptible to Cross-Site Scripting (XSS) attacks. If an attacker manages to inject malicious script or style tags into a page, the browser will execute them, potentially leading to data theft, session hijacking, or defacement.

🛡️ **Solution:** 
1. Moved the inline JavaScript logic (like setting up custom properties and the initialization of Wow.js and tooltips) to external files `assets/js/setup.js` and `assets/js/wow-init.js`, loading them via `<script defer src="...">`.
2. Extracted the inline style for the sidebar background (which previously used Jekyll's Liquid tag `{{ site.accent_image }}`) into a new `assets/css/custom_style.scss` file with frontmatter to ensure Jekyll still renders the variables. It is now loaded as an external stylesheet.
3. Updated the `<meta http-equiv="Content-Security-Policy">` tag to remove `'unsafe-inline'` from both `script-src` and `style-src`.

---
*PR created automatically by Jules for task [9999147597470267108](https://jules.google.com/task/9999147597470267108) started by @jacobceles*