### PR TITLE
🔒 Sentinel: Fix Insecure Content Security Policy (unsafe-eval)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,3 +1,8 @@
+## 2024-05-25 - Insecure Content Security Policy (unsafe-eval)
+**Vulnerability:** The Content Security Policy (CSP) included `'unsafe-eval'` in the `script-src` directive, allowing the execution of code generated from strings.
+**Learning:** Hardening CSP by removing `'unsafe-eval'` significantly mitigates XSS risks. Even if legacy libraries might traditionally suggest it, modern security standards prioritize its removal to prevent unauthorized code execution.
+**Prevention:** Always strive for a CSP that avoids `'unsafe-eval'`. Verify if scripts or libraries truly require it and look for CSP-compliant alternatives.
+
 ## 2024-05-24 - Missing Subresource Integrity (SRI) for CDN Scripts
 **Vulnerability:** External scripts loaded from CDNs without `integrity` and `crossorigin` attributes.
 **Learning:** Common libraries like jQuery, Bootstrap, and Popper were loaded from CDNs in the layout templates, which introduces a critical vulnerability if the CDN gets compromised.

--- a/_layouts/custom_base.html
+++ b/_layouts/custom_base.html
@@ -17,7 +17,7 @@
       <meta charset="utf-8">
       <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
       <meta http-equiv="x-ua-compatible" content="ie=edge">
-      <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://unpkg.com https://code.jquery.com https://cdn.jsdelivr.net https://stackpath.bootstrapcdn.com https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https://github.com; connect-src 'self'; object-src 'none'; frame-src 'self';">
+      <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://unpkg.com https://code.jquery.com https://cdn.jsdelivr.net https://stackpath.bootstrapcdn.com https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https://github.com; connect-src 'self'; object-src 'none'; frame-src 'self';">
       <!-- ⚡ Bolt Optimization: Preload critical LCP images to improve performance -->
       <link rel="preload" as="image" href="{{ site.accent_image }}" fetchpriority="high">
       <link rel="preload" as="image" href="{{ site.logo }}" fetchpriority="high">

--- a/knowledge_repo/colab_and_pyspark/index.html
+++ b/knowledge_repo/colab_and_pyspark/index.html
@@ -3,7 +3,7 @@
 <head>
 
 <meta charset="utf-8" />
-<meta http-equiv="Content-Security-Policy" content="default-src 'self' blob: data: gap:; style-src 'self' 'unsafe-inline' blob: data: gap:; script-src 'self' 'unsafe-eval' 'unsafe-inline' https://cdnjs.cloudflare.com blob: data: gap:; object-src 'self' blob: data: gap:; img-src 'self' 'unsafe-inline' https://jacobcelestine.com https://2s7gjr373w3x22jf92z99mgm5w-wpengine.netdna-ssl.com blob: data: gap:; connect-src 'self' 'unsafe-inline' blob: data: gap:; frame-src 'self' blob: data: gap:;">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self' blob: data: gap:; style-src 'self' 'unsafe-inline' blob: data: gap:; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com blob: data: gap:; object-src 'self' blob: data: gap:; img-src 'self' 'unsafe-inline' https://jacobcelestine.com https://2s7gjr373w3x22jf92z99mgm5w-wpengine.netdna-ssl.com blob: data: gap:; connect-src 'self' 'unsafe-inline' blob: data: gap:; frame-src 'self' blob: data: gap:;">
 <meta prefix="og: https://ogp.me/ns#" property="og:url" content="https://jacobcelestine.com/knowledge_repo/colab_and_pyspark/"/>
 <meta prefix="og: https://ogp.me/ns#" property="og:type" content="article"/>
 <meta prefix="og: https://ogp.me/ns#" property="og:title" content="Introduction to Google Colab, PySpark and EC2 Instances"/>


### PR DESCRIPTION
🎯 **What:** Insecure Content Security Policy (unsafe-eval)
⚠️ **Risk:** The presence of `'unsafe-eval'` in the CSP allows the execution of code generated from strings, significantly increasing the risk and impact of Cross-Site Scripting (XSS) attacks by allowing an attacker to bypass some CSP protections.
🛡️ **Solution:** Hardened the CSP by removing `'unsafe-eval'` from the `script-src` directive in the base layout (`_layouts/custom_base.html`) and standalone pages (`knowledge_repo/colab_and_pyspark/index.html`). Updated the security log in `.jules/sentinel.md` to document this fix.

---
*PR created automatically by Jules for task [1510070567709250169](https://jules.google.com/task/1510070567709250169) started by @jacobceles*