### PR TITLE
🔒 Remove insecure 'unsafe-eval' from Content-Security-Policy

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,3 +1,8 @@
+## 2026-05-01 - Hardening CSP by removing unsafe-eval
+**Vulnerability:** The Content Security Policy (CSP) in `_layouts/custom_base.html` included `'unsafe-eval'` in the `script-src` directive, allowing the execution of code generated from strings.
+**Learning:** Hardening CSP by removing `'unsafe-eval'` significantly mitigates XSS risks. Modern security standards prioritize its removal to prevent unauthorized code execution.
+**Prevention:** Always strive for a CSP that avoids `'unsafe-eval'`. Verify if scripts or libraries truly require it and look for CSP-compliant alternatives.
+
 ## 2024-05-25 - Insecure Content Security Policy (unsafe-eval)
 **Vulnerability:** The Content Security Policy (CSP) included `'unsafe-eval'` in the `script-src` directive, allowing the execution of code generated from strings.
 **Learning:** Hardening CSP by removing `'unsafe-eval'` significantly mitigates XSS risks. Even if legacy libraries might traditionally suggest it, modern security standards prioritize its removal to prevent unauthorized code execution.

--- a/_layouts/custom_base.html
+++ b/_layouts/custom_base.html
@@ -17,7 +17,7 @@
       <meta charset="utf-8">
       <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
       <meta http-equiv="x-ua-compatible" content="ie=edge">
-      <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-eval' https://unpkg.com https://code.jquery.com https://cdn.jsdelivr.net https://stackpath.bootstrapcdn.com https://cdnjs.cloudflare.com; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https://github.com; connect-src 'self'; object-src 'none'; frame-src 'self';">
+      <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://unpkg.com https://code.jquery.com https://cdn.jsdelivr.net https://stackpath.bootstrapcdn.com https://cdnjs.cloudflare.com; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https://github.com; connect-src 'self'; object-src 'none'; frame-src 'self';">
       <!-- ⚡ Bolt Optimization: Preload critical LCP images to improve performance -->
       <link rel="preload" as="image" href="{{ site.accent_image }}" fetchpriority="high">
       <link rel="preload" as="image" href="{{ site.logo }}" fetchpriority="high">


### PR DESCRIPTION
🎯 **What:** The Content-Security-Policy (CSP) in `_layouts/custom_base.html` included `'unsafe-eval'` in the `script-src` directive.

⚠️ **Risk:** Including `'unsafe-eval'` allows the execution of code generated from strings (e.g., `eval()`, `new Function()`), which can be exploited in Cross-Site Scripting (XSS) attacks to run unauthorized scripts in the context of the user's browser.

🛡️ **Solution:** Removed `'unsafe-eval'` from the `script-src` directive. Modern libraries included in the layout do not require it, and removing it significantly strengthens the site's security posture.

---
*PR created automatically by Jules for task [7491439113078385899](https://jules.google.com/task/7491439113078385899) started by @jacobceles*