### PR TITLE
🧹 Combine DOMContentLoaded event listeners in wow-init.js

### DIFF
--- a/assets/js/wow-init.js
+++ b/assets/js/wow-init.js
@@ -1,8 +1,4 @@
 window.addEventListener('DOMContentLoaded', function() {
     new WOW().init();
-});
-window.addEventListener('DOMContentLoaded', function() {
-    $(function () {
-        $('[data-toggle="tooltip"]').tooltip()
-    })
+    $('[data-toggle="tooltip"]').tooltip()
 });

--- a/assets/js/wow-init.test.js
+++ b/assets/js/wow-init.test.js
@@ -41,29 +41,19 @@ test('wow-init.js initialization', async (t) => {
   const scriptContent = fs.readFileSync(path.join(__dirname, 'wow-init.js'), 'utf8');
   eval(scriptContent);
 
-  await t.test('registers DOMContentLoaded listeners', () => {
-    assert.strictEqual(eventListeners['DOMContentLoaded'].length, 2);
+  await t.test('registers DOMContentLoaded listener', () => {
+    assert.strictEqual(eventListeners['DOMContentLoaded'].length, 1);
   });
 
-  await t.test('initializes WOW on DOMContentLoaded', () => {
-    // Clear mocks if necessary (not strictly needed here as it's the first time we call it)
-
-    // Execute the first callback
+  await t.test('initializes WOW and tooltips on DOMContentLoaded', () => {
+    // Execute the callback
     eventListeners['DOMContentLoaded'][0]();
 
+    // Check WOW initialization
     assert.strictEqual(wowInitMock.init.mock.callCount(), 1);
-  });
 
-  await t.test('initializes tooltips on DOMContentLoaded', () => {
-    // Execute the second callback
-    eventListeners['DOMContentLoaded'][1]();
-
-    const readyCallback = global.$.mock.calls[0].arguments[0];
-    assert.strictEqual(typeof readyCallback, 'function');
-
-    readyCallback();
-
-    assert.strictEqual(global.$.mock.calls[1].arguments[0], '[data-toggle="tooltip"]');
+    // Check tooltip initialization
+    assert.strictEqual(global.$.mock.calls[0].arguments[0], '[data-toggle="tooltip"]');
     assert.strictEqual(tooltipMock.mock.callCount(), 1);
   });
 });


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was the presence of multiple `DOMContentLoaded` event listeners in `assets/js/wow-init.js`.

💡 **Why:** Combining these listeners improves maintainability and readability by centralizing initialization logic. Removing the redundant jQuery wrapper further cleans up the code since the DOM is already guaranteed to be ready within the `DOMContentLoaded` callback.

✅ **Verification:** 
- Updated and ran unit tests in `assets/js/wow-init.test.js`, which passed successfully.
- Performed visual verification using a Playwright script targeting the `/projects/` page (where these initializations are active) to ensure no regressions in WOW.js or tooltip behavior.
- Verified that no temporary files or build artifacts were included in the commit.

✨ **Result:** A cleaner, more maintainable `wow-init.js` with synchronized unit tests.

---
*PR created automatically by Jules for task [6430989125024937471](https://jules.google.com/task/6430989125024937471) started by @jacobceles*