### PR TITLE
🔒 Fix insecure CSP (unsafe-inline) in Colab and PySpark tutorial

### DIFF
--- a/knowledge_repo/colab_and_pyspark/default.css
+++ b/knowledge_repo/colab_and_pyspark/default.css
@@ -1,4 +1,3 @@
-<style type="text/css">
     /*!
 *
 * Twitter Bootstrap
@@ -9123,12 +9122,10 @@ model layouts accross multiple browsers, including older browsers.  The newest,
 universal implementation of the flexible box model is used when available (see
 `Modern browsers` comments below).  Browsers that are known to implement this 
 new spec completely include:
-
     Firefox 28.0+
     Chrome 29.0+
     Internet Explorer 11+ 
     Opera 17.0+
-
 Browsers not listed, including Safari, are supported via the styling under the
 `Old browsers` comments below.
 */
@@ -10700,10 +10697,8 @@ div.input_area > div.highlight > pre {
   }
 }
 /*
-
 Original style from softwaremaniacs.org (c) Ivan Sagalaev <Maniac@SoftwareManiacs.Org>
 Adapted from GitHub theme
-
 */
 .highlight-base {
   color: #000;
@@ -12930,8 +12925,6 @@ ul.typeahead-list  > li > a.pull-right {
   margin-top: 20px;
 }
 /*# sourceMappingURL=style.min.css.map */
-    </style>
-<style type="text/css">
     .highlight .hll { background-color: #ffffcc }
 .highlight  { background: #f8f8f8; }
 .highlight .c { color: #408080; font-style: italic } /* Comment */
@@ -13001,16 +12994,11 @@ ul.typeahead-list  > li > a.pull-right {
 .highlight .vi { color: #19177C } /* Name.Variable.Instance */
 .highlight .vm { color: #19177C } /* Name.Variable.Magic */
 .highlight .il { color: #666666 } /* Literal.Number.Integer.Long */
-    </style>
-
-
-<style type="text/css">
 /* Overrides of notebook CSS for static HTML export */
 body {
   overflow: visible;
   padding: 8px;
 }
-
 div#notebook {
   overflow: visible;
   border-top: none;
@@ -13028,4 +13016,21 @@ div#notebook {
     page-break-inside: avoid; 
   }
 }
-</style>
+/* Custom classes for CSP compliance */
+.bg-black {
+  background-color: black;
+}
+.text-underline {
+  text-decoration: underline;
+}
+.text-muted-custom {
+  text-align: center;
+  color: #666956;
+}
+.footer-custom {
+  text-align: center;
+  font-size: 8pt;
+  line-height: 10pt;
+  font-family: 'Cambria', 'times roman', serif;
+  color: #fff;
+}

--- a/knowledge_repo/colab_and_pyspark/index.html
+++ b/knowledge_repo/colab_and_pyspark/index.html
@@ -3,7 +3,7 @@
 <head>
 
 <meta charset="utf-8" />
-<meta http-equiv="Content-Security-Policy" content="default-src 'self' blob: data: gap:; style-src 'self' 'unsafe-inline' blob: data: gap:; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com blob: data: gap:; object-src 'self' blob: data: gap:; img-src 'self' 'unsafe-inline' https://jacobcelestine.com https://2s7gjr373w3x22jf92z99mgm5w-wpengine.netdna-ssl.com blob: data: gap:; connect-src 'self' 'unsafe-inline' blob: data: gap:; frame-src 'self' blob: data: gap:;">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self' blob: data: gap:; style-src 'self' blob: data: gap:; script-src 'self' https://cdnjs.cloudflare.com blob: data: gap:; object-src 'self' blob: data: gap:; img-src 'self' https://jacobcelestine.com https://2s7gjr373w3x22jf92z99mgm5w-wpengine.netdna-ssl.com blob: data: gap:; connect-src 'self' blob: data: gap:; frame-src 'self' blob: data: gap:;">
 <meta prefix="og: https://ogp.me/ns#" property="og:url" content="https://jacobcelestine.com/knowledge_repo/colab_and_pyspark/"/>
 <meta prefix="og: https://ogp.me/ns#" property="og:type" content="article"/>
 <meta prefix="og: https://ogp.me/ns#" property="og:title" content="Introduction to Google Colab, PySpark and EC2 Instances"/>
@@ -24,32 +24,16 @@
 <!-- Load mathjax -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS_HTML" integrity="sha384-3lJUsx1TJHt7BA4udB5KPnDrlkO8T6J6v/op7ui0BbCjvZ9WqV4Xm6DTP6kQ/iBH" crossorigin="anonymous"></script>
     <!-- MathJax configuration -->
-    <script type="text/x-mathjax-config">
-    MathJax.Hub.Config({
-        tex2jax: {
-            inlineMath: [ ['$','$'], ["\\(","\\)"] ],
-            displayMath: [ ['$$','$$'], ["\\[","\\]"] ],
-            processEscapes: true,
-            processEnvironments: true
-        },
-        // Center justify equations in code and markdown cells. Elsewhere
-        // we use CSS to left justify single line equations in code cells.
-        displayAlign: 'center',
-        "HTML-CSS": {
-            styles: {'.MathJax_Display': {"margin": 0}},
-            linebreaks: { automatic: true }
-        }
-    });
-    </script>
+    <script type="text/javascript" src="mathjax-config.js"></script>
     <!-- End of mathjax configuration --></head>
-<body style="background-color:black;">
+<body class="bg-black">
   <div tabindex="-1" id="notebook" class="border-box-sizing">
     <div class="container" id="notebook-container">
 
 <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
 </div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<h1 style="text-align: center;">Introduction to Google Colab and PySpark</h1>
+<h1 class="text-center">Introduction to Google Colab and PySpark</h1>
 </div>
 </div>
 </div>
@@ -219,14 +203,14 @@ If you want to try out things with this notebook as a base, feel free to downloa
 <p>Imagine your data resides in a distributed manner at different places. If you try brining your data to one point and executing your code there, not only would that be inefficent, but also cause memory issues. Now let's say your code goes to the data rather than the data coming to where your code. This will help avoid unneccesary data movement which will thereby decrease the running time.</p>
 <p>PySpark is the Python API of Spark; which means it can do almost all the things python can. Machine learning(ML) pipelines, exploratory data analysis (at scale), ETLs for data platform, and much more! And all of them in a distributed manner. One of the best parts of pyspark is that if you are already familiar with python, it's really easy to learn.</p>
 <p>Apart from PySpark, there is another language called Scala used for big data processing. Scala is frequently over 10 times faster than <em>Python</em>, as it is native for Hadoop as its based on JVM. But PySpark is getting adopted at a fast rate because of the ease of use, easier learning curve and ML capabilities.</p>
-<p>I will briefly explain how a PySpark job works, but I strongly recommend you read more about the <a href="https://data-flair.training/blogs/how-apache-spark-works/">architecture</a> and how everything works. Now, before I get into it, let me talk about some <span style="text-decoration: underline;">basic jargons</span> first:</p>
+<p>I will briefly explain how a PySpark job works, but I strongly recommend you read more about the <a href="https://data-flair.training/blogs/how-apache-spark-works/">architecture</a> and how everything works. Now, before I get into it, let me talk about some <span class="text-underline">basic jargons</span> first:</p>
 <p><b>Cluster</b> is a set of loosely or tightly connected computers that work together so that they can be viewed as a single system.</p>
 <p><b>Hadoop</b> is an open source, scalable, and fault tolerant framework written in Java. It efficiently processes large volumes of data on a cluster of commodity hardware. Hadoop is not only a storage system but is a platform for large data storage as well as processing.</p>
 <p><b>HDFS</b> (Hadoop distributed file system). It is one of the world's most reliable storage system. HDFS is a Filesystem of Hadoop designed for storing very large files running on a cluster of commodity hardware.</p>
 <p><b>MapReduce</b> is a data Processing framework, which has 2 phases - Mapper and Reducer. The map procedure performs filtering and sorting, and the reduce method performs a summary operation. It usually runs on a hadoop cluster.</p>
 <p><b>Transformation</b> refers to the operations applied on a dataset to create a new dataset. Filter, groupBy and map are the examples of transformations.</p>
 <p><b>Actions</b> Actions refer to an operation which instructs Spark to perform computation and send the result back to driver. This is an example of action.</p>
-<p>Alright! Now that that's out of the way, let me explain how a spark job runs. In simple terma, each time you submit a pyspark job, the code gets internally converted into a MapReduce program and gets executed in the Java virtual machine. Now one of the thoughts that might be popping in your mind will probably be: <br><code>So the code gets converted into a MapReduce program. Wouldn't that mean MapReduce is faster than pySpark?</code><br> Well, the answer is a big NO. This is what makes spark jobs special. Spark is capable of handling a massive amount of data at a time, in it's distributed environment. It does this through <span style="text-decoration: underline;">in-memory processing</span>, which is what makes it almost 100 times faster than Hadoop. Another factor which amkes it fast is <span style="text-decoration: underline;">Lazy Evaluation</span>. Spark delays its evaluation as much as it can. Each time you  submit a job, spark creates an action plan for how to execute the code, and then does nothing. Finally, when you ask for the result(i.e, calls an action), it executes the plan, which is basically all the transofrmations you have mentioned in your code. That's basically the gist of it.</p>
+<p>Alright! Now that that's out of the way, let me explain how a spark job runs. In simple terma, each time you submit a pyspark job, the code gets internally converted into a MapReduce program and gets executed in the Java virtual machine. Now one of the thoughts that might be popping in your mind will probably be: <br><code>So the code gets converted into a MapReduce program. Wouldn't that mean MapReduce is faster than pySpark?</code><br> Well, the answer is a big NO. This is what makes spark jobs special. Spark is capable of handling a massive amount of data at a time, in it's distributed environment. It does this through <span class="text-underline">in-memory processing</span>, which is what makes it almost 100 times faster than Hadoop. Another factor which amkes it fast is <span class="text-underline">Lazy Evaluation</span>. Spark delays its evaluation as much as it can. Each time you  submit a job, spark creates an action plan for how to execute the code, and then does nothing. Finally, when you ask for the result(i.e, calls an action), it executes the plan, which is basically all the transofrmations you have mentioned in your code. That's basically the gist of it.</p>
 <p>Now lastly, I want to talk about on more thing. Spark mainly consists of 4 modules:</p>
 <ol>
     <li>Spark SQL - helps to write  spark programs using SQL like queries.</li>
@@ -235,7 +219,7 @@ If you want to try out things with this notebook as a base, feel free to downloa
     <li>Spark GraphX - is the visualization component of Spark. It enables users to view data both as graphs and as collections without data movement or duplication.</li>
 </ol><p>Hopefully this image gives a better idea of what I am talking about:
 <img alt="Spark Modules" src="https://2s7gjr373w3x22jf92z99mgm5w-wpengine.netdna-ssl.com/wp-content/uploads/2015/11/spark-streaming-datanami.png" loading="lazy" /></p>
-<p style="text-align: center; color: #666956;">Source: Datanami</p>
+<p class="text-muted-custom">Source: Datanami</p>
 
 </div>
 </div>
@@ -4593,7 +4577,7 @@ As you can see, my shuffle partitions should be 1050, not 200.</p>
     </div>
   </div>
   <br><br>
-  <p style="text-align: center; font-size:8pt; line-height:10pt; font-family: 'Cambria','times roman',serif; color: #fff">© Jacob Celestine 2021<br>This content is fully original. All the write-ups is either original or have been properly credited to their sources, if any, and the original link to the dataset has also been provided.<br>All the code has been written by myself without referring anywhere, using knowledge gained through my experience and multiple courses I have attended over the years. If you have any issues, please <a href="mailto:jacobceles@gmail.com">write to me</a> before anything else.<br>The dataset has been sourced from <a href="https://perso.telecom-paristech.fr/eagan/class/igr204/datasets">Project Datasets</a> and have been cleaned up by Petra Isenberg, Pierre Dragicevic and Yvonne Jansen.</p>
+  <p class="footer-custom">© Jacob Celestine 2021<br>This content is fully original. All the write-ups is either original or have been properly credited to their sources, if any, and the original link to the dataset has also been provided.<br>All the code has been written by myself without referring anywhere, using knowledge gained through my experience and multiple courses I have attended over the years. If you have any issues, please <a href="mailto:jacobceles@gmail.com">write to me</a> before anything else.<br>The dataset has been sourced from <a href="https://perso.telecom-paristech.fr/eagan/class/igr204/datasets">Project Datasets</a> and have been cleaned up by Petra Isenberg, Pierre Dragicevic and Yvonne Jansen.</p>
   <br>
 </body>
 </html>

--- a/knowledge_repo/colab_and_pyspark/mathjax-config.js
+++ b/knowledge_repo/colab_and_pyspark/mathjax-config.js
@@ -1,0 +1,15 @@
+MathJax.Hub.Config({
+    tex2jax: {
+        inlineMath: [ ['$','$'], ["\\(","\\)"] ],
+        displayMath: [ ['$$','$$'], ["\\[","\\]"] ],
+        processEscapes: true,
+        processEnvironments: true
+    },
+    // Center justify equations in code and markdown cells. Elsewhere
+    // we use CSS to left justify single line equations in code cells.
+    displayAlign: 'center',
+    "HTML-CSS": {
+        styles: {'.MathJax_Display': {"margin": 0}},
+        linebreaks: { automatic: true }
+    }
+});


### PR DESCRIPTION
This PR fixes a security vulnerability where the Content Security Policy (CSP) in `knowledge_repo/colab_and_pyspark/index.html` used `'unsafe-inline'`.

Key changes:
1.  **CSP Hardening:** Removed `'unsafe-inline'` from `script-src`, `style-src`, `img-src`, and `connect-src`.
2.  **Externalized Styles:** Migrated inline `style` attributes to `knowledge_repo/colab_and_pyspark/default.css` using new utility classes (`.bg-black`, `.text-center`, `.text-underline`, `.text-muted-custom`, `.footer-custom`).
3.  **Externalized Scripts:** Moved the inline MathJax configuration block to `knowledge_repo/colab_and_pyspark/mathjax-config.js`.
4.  **CSS Cleanup:** Removed erroneous `<style>` and `</style>` tags that were present inside `default.css`.
5.  **Verification:** Verified the fix by ensuring the page renders correctly and external resources are loaded as expected. Addressing code review feedback, I also removed the `defer` attribute from the MathJax config script and removed an accidental log file.

---
*PR created automatically by Jules for task [13087637645852099200](https://jules.google.com/task/13087637645852099200) started by @jacobceles*